### PR TITLE
Minor bug: Prevent hanging tags

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -263,9 +263,6 @@ function handleBeslistTag() {
       callInWindow("bslst_initialize_session", custom_location);
     }
   }
-
-  // Call data.gtmOnSuccess when the tag is finished.
-  data.gtmOnSuccess();
 }
 
 function onInjectScriptSuccess(){
@@ -273,6 +270,7 @@ function onInjectScriptSuccess(){
 
   if (isConsentGranted('ad_storage')) {
     handleBeslistTag();
+    data.gtmOnSuccess();
     return;
   }
 
@@ -297,6 +295,8 @@ function onInjectScriptSuccess(){
     firedConsentHandler = true;
     handleBeslistTag();
   });
+
+  data.gtmOnSuccess();
 }
 
 function onInjectScriptFailure(){


### PR DESCRIPTION
Tags can stay in the "running" state forever when no ad_storage consent is ever granted. 

Solution:
Call data.gtmOnSuccess() as soon as data has been sent to Beslist OR is stored in the floodgate.